### PR TITLE
Treat a link to a bot response just like a reply

### DIFF
--- a/inatcog/commands/inat.py
+++ b/inatcog/commands/inat.py
@@ -289,6 +289,35 @@ class CommandsInat(INatEmbeds, MixinMeta):
         """Convenient alias for 'describe query' message command."""
         await ctx.send_help(self.bot.get_command("describe query"))
 
+    @describe.command(name="reply", aliases=["replies"])
+    async def describe_reply(self, ctx):
+        """\u200b*Reply* and *Link* command chaining.
+
+        You can chain together commands as either a Discord Reply
+        or Link to a bot response. Arguments from both commands
+        will be combined.
+
+        __Reply chaining:__
+        - `[p]t cellophane bees`
+        - On the Colletes taxon response from the bot, select "Reply"
+          from the message menu and type the next command ...
+        - `[p]life from canada`
+        - The result is a life list of Colletes from Canada.
+
+        __Link chaining:__
+        - `[p]t cellophane bees`
+        - On the Colletes taxon response from the bot,
+          select "Copy Message Link" from the message menu.
+        - In another channel or DM to the bot, where it says `<link>`
+          below, paste the link you copied (without the angle-brackets)
+        - `[p]life <link> from canada`
+        - The result is the same as the Reply example above,
+          except in the new channel or DM.
+
+        See also: `[p]query`.
+        """  # noqa: E501
+        await ctx.send_help()
+
     @describe.command(name="advanced")
     async def describe_advanced(self, ctx):
         """\u200b*Advanced* query options via `opt`.
@@ -393,6 +422,11 @@ class CommandsInat(INatEmbeds, MixinMeta):
     async def topic_reaction(self, ctx):
         """Convenient alias for 'describe reactions' message command."""
         await ctx.send_help(self.bot.get_command("describe reactions"))
+
+    @commands.command(name="reply", aliases=["replies"], hidden=True)
+    async def topic_reply(self, ctx):
+        """Convenient alias for 'describe reply' message command."""
+        await ctx.send_help(self.bot.get_command("describe reply"))
 
     @commands.group()
     async def inat(self, ctx):

--- a/inatcog/commands/obs.py
+++ b/inatcog/commands/obs.py
@@ -203,7 +203,7 @@ class CommandsObs(INatEmbeds, MixinMeta):
     async def life(self, ctx, *, query: Optional[Union[TaxonReplyConverter, str]]):
         """Life list with observation totals.
 
-        • The title links to a user's life list or to species view.
+        • If the life list is for one user, the title links to it.
         • Buttons to change `per` details and taxon root:
           • :leaves: toggles alphabetial list of leaf taxa.
           • :arrow_up_down: changes rank detail level: main (default), any, or selected taxon.

--- a/inatcog/converters/reply.py
+++ b/inatcog/converters/reply.py
@@ -1,14 +1,23 @@
 """Reply converters."""
+import logging
+import re
 
+from discord import Message, MessageReference
 from redbot.core.commands import BadArgument, Context
 from dronefly.core.query.query import EMPTY_QUERY
 from inatcog.embeds.inat import INatEmbed
 from .base import NaturalQueryConverter
 
+DISCORD_MSG_PAT = re.compile(
+    r"^(https://discord\.com/channels/((?P<me>@me)|(?P<guildid>\d{18}))"
+    r"/(?P<channelid>\d{18})/(?P<messageid>\d{19}))"
+)
+
+logger = logging.getLogger("red.dronefly." + __name__)
+
+
 # pylint: disable=no-member, assigning-non-slot
 # - See https://github.com/PyCQA/pylint/issues/981
-
-
 class EmptyArgument(BadArgument):
     """Argument to a command is empty."""
 
@@ -20,23 +29,56 @@ class TaxonReplyConverter:
     async def convert(cls, ctx: Context, argument: str = "", allow_empty: bool = False):
         """Default to taxon from replied to bot message."""
 
-        async def get_query_from_ref_msg(ref, query_str: str):
-            """Return a query string from the referenced embed."""
-            msg = ref.cached_message
-            _query_str = query_str
-            if not msg:
-                # See comment below for why the user won't see this message with
-                # our current approach:
-                if (
-                    ctx.guild
-                    and not ctx.channel.permissions_for(
-                        ctx.guild.me
-                    ).read_message_history
-                ):
+        async def get_query_from_link(link: re.Match, query_str: str):
+            logger.debug("link = %r\nquery_str = %r", link, query_str)
+            channel_id = int(link["channelid"])
+            if link["guildid"]:
+                guild_id = int(link["guildid"])
+                guild = ctx.bot.get_guild(guild_id)
+                logger.debug("guild = %r", guild)
+                if not guild.get_member(guild.me.id):
                     raise BadArgument(
-                        "I need Read Message History permission to read that message."
+                        "I need to be a member of the linked server to read that message"
                     )
-                msg = await ctx.channel.fetch_message(ref.message_id)
+                if not guild.get_member(ctx.author.id):
+                    raise BadArgument(
+                        "You need to be a member of the linked server to read that message"
+                    )
+                channel = guild.get_channel(channel_id)
+            else:
+                logger.debug("channel_id = %r", channel_id)
+                channel = ctx.bot.get_channel(channel_id)
+                if not channel:
+                    raise BadArgument(
+                        "I need to be in that private DM to read that message"
+                    )
+                if ctx.author != channel.recipient:
+                    raise BadArgument(
+                        "You need to be in that private DM to read that message"
+                    )
+            message_id = int(link["messageid"])
+            logger.debug("channel = %r", channel)
+            msg = next((m for m in ctx.bot.cached_messages if m.id == message_id), "")
+            if not msg:
+                if ctx.guild:
+                    if not channel.permissions_for(ctx.guild.me).read_message_history:
+                        raise BadArgument(
+                            "I need Read Message History permission to read that message"
+                        )
+                    if not channel.permissions_for(ctx.author).read_message_history:
+                        raise BadArgument(
+                            "You need Read Message History permission to read that message"
+                        )
+                msg = await channel.fetch_message(message_id)
+                logger.debug("msg = %r", msg)
+            else:
+                logger.debug("msg (cached) = %r", msg)
+            _query_str = query_str.replace(link[0], "")
+            logger.debug("_query_str = %r", _query_str)
+            return await get_query_from_msg(msg, _query_str)
+
+        async def get_query_from_msg(msg: Message, query_str: str):
+            _query_str = query_str
             if msg and msg.author.bot and msg.embeds:
                 embed = next(
                     (embed for embed in msg.embeds if embed.type == "rich"), None
@@ -61,19 +103,41 @@ class TaxonReplyConverter:
             if not _query_str:
                 if ref:
                     if not msg:
-                        raise BadArgument(
-                            "I couldn't fetch the message for that reply."
-                        )
+                        raise BadArgument("I couldn't fetch that message.")
                     raise BadArgument(
-                        "I couldn't recognize the message content for that reply."
+                        "I couldn't recognize the content in that message."
                     )
             return _query_str
 
+        async def get_query_from_ref_msg(ref: MessageReference, query_str: str):
+            """Return a query string from the referenced embed."""
+            msg = ref.cached_message
+            if not msg:
+                # See comment below for why the user won't see this message with
+                # our current approach:
+                if (
+                    ctx.guild
+                    and not ctx.channel.permissions_for(
+                        ctx.guild.me
+                    ).read_message_history
+                ):
+                    raise BadArgument(
+                        "I need Read Message History permission to read that message."
+                    )
+                msg = await ctx.channel.fetch_message(ref.message_id)
+            return await get_query_from_msg(msg, query_str)
+
         ref = ctx.message.reference
         if ref:
+            logger.debug("ref = %r", ref)
             query_str = await get_query_from_ref_msg(ref, argument)
         else:
-            query_str = argument
+            logger.debug("argument = %r", argument)
+            link = DISCORD_MSG_PAT.search(argument)
+            if link:
+                query_str = await get_query_from_link(link, argument)
+            else:
+                query_str = argument
         if not query_str:
             if allow_empty:
                 return EMPTY_QUERY


### PR DESCRIPTION
The feature works when the first argument is:

- a link to a bot response from another channel in the same server
- a link to a bot response on another server where the bot and the user are both members
- a link to a bot response in a private message from the bot to the user
- a link to a bot response from a server channel where the bot and user are both members sent in a private message to the bot

An error will be returned when the link doesn't match one of the four cases above.

Just as in using Discord Reply to a bot response, the remaining arguments of the command after the link argument are combined with the commands from the bot response to make a new command. In this way, a complex query can be built up from a series of simpler queries without retyping all of the arguments for the replied-to or linked-to command response.